### PR TITLE
changed apiversion to apps/v1 for app-envvars/deployment-with-envvars…

### DIFF
--- a/k8s/app-envvars/deployment-with-envvars.yaml
+++ b/k8s/app-envvars/deployment-with-envvars.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
Changed apiVersion in `k8s/app-envvars/deployment-with-envvars.yaml` to `apps/v1` to keep consistent with other manifests. This should be valid for any k8s versions > 1.16.